### PR TITLE
feat: Add missing smartlead_get_campaign_analytics tool

### DIFF
--- a/src/modules/campaigns/client.ts
+++ b/src/modules/campaigns/client.ts
@@ -145,6 +145,17 @@ export class CampaignClient extends BaseSmartLeadClient {
   }
 
   /**
+   * Get campaign analytics (simple - no date filtering)
+   */
+  async getCampaignAnalytics(campaignId: number): Promise<any> {
+    const response = await this.withRetry(
+      () => this.apiClient.get(`/campaigns/${campaignId}/analytics`),
+      'get campaign analytics'
+    );
+    return response.data;
+  }
+
+  /**
    * Fetch campaign analytics by date range
    */
   async fetchCampaignAnalyticsByDateRange(campaignId: number, params: any): Promise<any> {

--- a/src/tools/campaigns.ts
+++ b/src/tools/campaigns.ts
@@ -376,4 +376,28 @@ export function registerCampaignTools(
       }
     }
   );
+
+  // Get Campaign Analytics Tool (Simple - no date filtering)  
+  server.registerTool(
+    'smartlead_get_campaign_analytics',
+    {
+      title: 'Get Campaign Analytics', 
+      description: 'Get comprehensive analytics data for a specific campaign including sent count, open count, reply count, bounce count, and lead statistics.',
+      inputSchema: GetCampaignRequestSchema.shape
+    },
+    async (params) => {
+      try {
+        const validatedParams = GetCampaignRequestSchema.parse(params);
+        const result = await client.campaigns.getCampaignAnalytics(validatedParams.campaign_id);
+        
+        return formatSuccessResponse(
+          'Campaign analytics retrieved successfully',
+          result,
+          `Analytics for campaign ${validatedParams.campaign_id}: ${result.sent_count} sent, ${result.reply_count} replies, ${result.open_count} opens`
+        );
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
 }


### PR DESCRIPTION
## 🎯 Overview

This PR adds the missing `smartlead_get_campaign_analytics` MCP tool that was referenced in documentation but not implemented in the codebase.

## 🐛 Problem

The `smartlead_get_campaign_analytics` tool was listed in various documentation and test files but was not actually registered as an MCP tool, causing failures when users tried to use it.

## ✅ Solution

**Added two components:**

1. **Client Method** (`src/modules/campaigns/client.ts`):
   - Added `getCampaignAnalytics(campaignId: number)` method
   - Calls `/campaigns/{id}/analytics` endpoint
   - No date parameters (API doesn't accept them)

2. **MCP Tool** (`src/tools/campaigns.ts`):
   - Added `smartlead_get_campaign_analytics` tool registration
   - Uses `GetCampaignRequestSchema` for validation
   - Returns comprehensive campaign analytics

## 📊 What This Tool Provides

The tool returns comprehensive campaign analytics including:
- Sent count, open count, reply count, bounce count
- Campaign status and sequence information  
- Lead statistics (total, completed, interested, blocked, etc.)
- Client information (name, email, company)

## 🧪 Testing

- ✅ Verified tool registration works correctly
- ✅ Confirmed API endpoint responds successfully
- ✅ Validated return data structure matches expected schema
- ✅ Tested with real SmartLead API data

## 📝 Files Changed

- `src/modules/campaigns/client.ts` - Added getCampaignAnalytics method
- `src/tools/campaigns.ts` - Added smartlead_get_campaign_analytics tool

## 🔗 Usage Example

```typescript
// Tool accepts campaign_id parameter
{
  "campaign_id": 12345
}

// Returns comprehensive analytics
{
  "id": 12345,
  "name": "Campaign Name",
  "sent_count": "1000",
  "open_count": "250", 
  "reply_count": "45",
  "bounce_count": "12",
  "status": "ACTIVE",
  "campaign_lead_stats": {
    "total": 500,
    "completed": 450,
    "interested": 25,
    "blocked": 5
  },
  // ...additional fields
}
```

This is a straightforward addition that fills a gap in the existing MCP tool coverage.